### PR TITLE
Limit playground builds to requested platform dependencies

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -89,3 +89,7 @@ common --define=enable_web=true
 build --android_crosstool_top="@snap_client_toolchains//:android_crosstool"
 # Web build configuration (used by scripts/bazel_web_serve.sh)
 build:web --build_tag_filters=web
+build:ios --repo_env=VALDI_PLATFORM_DEPENDENCIES=ios
+build:android --repo_env=VALDI_PLATFORM_DEPENDENCIES=android
+build:macos --repo_env=VALDI_PLATFORM_DEPENDENCIES=macos
+build:web --repo_env=VALDI_PLATFORM_DEPENDENCIES=cli

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -57,9 +57,13 @@ maybe(
     name = "host_platform",
 )
 
-load("@valdi//bzl:workspace_init.bzl", "valdi_initialize_workspace")
+load("@valdi//bzl:workspace_init.bzl", "platform_dependency_rule", "valdi_initialize_workspace")
 
-valdi_initialize_workspace()
+platform_dependency_rule(name = "platform_check")
+
+load("@platform_check//:target_platform.bzl", "VALDI_PLATFORM_DEPENDENCIES")
+
+valdi_initialize_workspace(VALDI_PLATFORM_DEPENDENCIES)
 
 load("@valdi_npm//:repositories.bzl", "npm_repositories")
 

--- a/scripts/bazel_android_install.sh
+++ b/scripts/bazel_android_install.sh
@@ -9,7 +9,7 @@ ROOT_DIR="$SCRIPT_DIR/../"
 START_ACTIVITY="com.snap.valdi.playground/.StartActivity"
 
 pushd "$ROOT_DIR"
-bazel build --repo_env=VALDI_PLATFORM_DEPENDENCIES=android "//valdi_modules/playground:app_android"
+bazel build --config=android "//valdi_modules/playground:app_android"
 adb install -r "bazel-bin/valdi_modules/playground/app_android.apk"
 adb shell am start -n $START_ACTIVITY
 

--- a/scripts/bazel_android_install.sh
+++ b/scripts/bazel_android_install.sh
@@ -9,7 +9,7 @@ ROOT_DIR="$SCRIPT_DIR/../"
 START_ACTIVITY="com.snap.valdi.playground/.StartActivity"
 
 pushd "$ROOT_DIR"
-bazel build "//valdi_modules/playground:app_android"
+bazel build --repo_env=VALDI_PLATFORM_DEPENDENCIES=android "//valdi_modules/playground:app_android"
 adb install -r "bazel-bin/valdi_modules/playground/app_android.apk"
 adb shell am start -n $START_ACTIVITY
 

--- a/scripts/bazel_ios_install.sh
+++ b/scripts/bazel_ios_install.sh
@@ -12,7 +12,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 ROOT_DIR="$SCRIPT_DIR/../"
 
 pushd "$ROOT_DIR"
-bazel build --repo_env=VALDI_PLATFORM_DEPENDENCIES=ios //valdi_modules/playground:app_ios
+bazel build --config=ios //valdi_modules/playground:app_ios
 TARGET_TEMP_DIR=`mktemp`
 rm "$TARGET_TEMP_DIR"
 mkdir "$TARGET_TEMP_DIR"

--- a/scripts/bazel_ios_install.sh
+++ b/scripts/bazel_ios_install.sh
@@ -12,7 +12,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 ROOT_DIR="$SCRIPT_DIR/../"
 
 pushd "$ROOT_DIR"
-bazel build //valdi_modules/playground:app_ios
+bazel build --repo_env=VALDI_PLATFORM_DEPENDENCIES=ios //valdi_modules/playground:app_ios
 TARGET_TEMP_DIR=`mktemp`
 rm "$TARGET_TEMP_DIR"
 mkdir "$TARGET_TEMP_DIR"

--- a/scripts/bazel_macos_run.sh
+++ b/scripts/bazel_macos_run.sh
@@ -12,6 +12,6 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 ROOT_DIR="$SCRIPT_DIR/../"
 
 pushd "$ROOT_DIR"
-bazel build "//valdi_modules/playground:app_macos"
+bazel build --repo_env=VALDI_PLATFORM_DEPENDENCIES=macos "//valdi_modules/playground:app_macos"
 ./bazel-bin/valdi_modules/playground/app_macos_bin
 popd

--- a/scripts/bazel_macos_run.sh
+++ b/scripts/bazel_macos_run.sh
@@ -12,6 +12,6 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 ROOT_DIR="$SCRIPT_DIR/../"
 
 pushd "$ROOT_DIR"
-bazel build --repo_env=VALDI_PLATFORM_DEPENDENCIES=macos "//valdi_modules/playground:app_macos"
+bazel build --config=macos "//valdi_modules/playground:app_macos"
 ./bazel-bin/valdi_modules/playground/app_macos_bin
 popd

--- a/scripts/bazel_web_serve.sh
+++ b/scripts/bazel_web_serve.sh
@@ -21,7 +21,7 @@ if command -v lsof &>/dev/null && lsof -i ":$PORT" -sTCP:LISTEN -t &>/dev/null; 
 fi
 
 echo "Building web bundle..."
-bazel build "$WEB_TARGET"
+bazel build --repo_env=VALDI_PLATFORM_DEPENDENCIES=cli "$WEB_TARGET"
 
 OUT_DIR="$ROOT_DIR/bazel-bin/valdi_modules/playground/playground_export_npm"
 if [[ ! -d "$OUT_DIR" ]]; then

--- a/scripts/bazel_web_serve.sh
+++ b/scripts/bazel_web_serve.sh
@@ -21,7 +21,7 @@ if command -v lsof &>/dev/null && lsof -i ":$PORT" -sTCP:LISTEN -t &>/dev/null; 
 fi
 
 echo "Building web bundle..."
-bazel build --repo_env=VALDI_PLATFORM_DEPENDENCIES=cli "$WEB_TARGET"
+bazel build --config=web "$WEB_TARGET"
 
 OUT_DIR="$ROOT_DIR/bazel-bin/valdi_modules/playground/playground_export_npm"
 if [[ ! -d "$OUT_DIR" ]]; then


### PR DESCRIPTION
## Summary

Problem this solves: don't build use platform level stuff that I'm not trying to build (Android NDK when building Mac OS app, example)

- Scope Valdi workspace initialization to the selected platform by wiring `platform_dependency_rule` and `VALDI_PLATFORM_DEPENDENCIES` into `WORKSPACE`.
- Use platform Bazel configs (`--config=ios|android|macos|web`) and switch playground scripts to those configs.
- Prevent non-Android builds from resolving Android toolchain dependencies indirectly.

## Changes
- `WORKSPACE`
  - Add `platform_dependency_rule` and `VALDI_PLATFORM_DEPENDENCIES`.
  - Call `valdi_initialize_workspace(VALDI_PLATFORM_DEPENDENCIES)`.
- `.bazelrc`
  - Add `build:ios`, `build:android`, `build:macos`, `build:web` repo env mappings.
- Playground scripts
  - `scripts/bazel_ios_install.sh`
  - `scripts/bazel_android_install.sh`
  - `scripts/bazel_macos_run.sh`
  - `scripts/bazel_web_serve.sh`

## Verification
- `bazel build --config=macos --nobuild //valdi_modules/playground:app_macos`
- `bazel build --config=web //valdi_modules/playground:playground_export_npm`
