### PR TITLE
Suppress -Wunknown-warning-option for Clang-version portability

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -23,6 +23,10 @@ build --cxxopt=-std=c++20
 build --cxxopt=-Wno-ambiguous-reversed-operator
 build --cxxopt=-Wno-gcc-compat
 build --cxxopt=-Wno-nullability-extension
+# Some Clang versions don't know about the two warnings below yet; without
+# this, an unrecognized -Wno-* flag is itself a fatal error under -Werror.
+build --cxxopt=-Wno-unknown-warning-option
+build --host_cxxopt=-Wno-unknown-warning-option
 # Newer Clang enables these under -Wall by default; Valdi's vendored
 # third-party/yoga and Hermes still trip them.
 build --cxxopt=-Wno-deprecated-literal-operator


### PR DESCRIPTION
## Summary
- #18 added \`-Wno-deprecated-literal-operator\` and \`-Wno-nontrivial-memcall\` to work around newer Clang (GitHub's macos-latest runner) flagging vendored Valdi third-party code under \`-Wall\` by default.
- Those flag names are unrecognized on older Clang (e.g. Apple Clang 17), and Valdi's repo-wide \`-Werror\` turns the resulting \`-Wunknown-warning-option\` into a build failure — breaking local builds for anyone not on the exact Clang version CI happens to use.
- Adds \`-Wno-unknown-warning-option\` (both \`--cxxopt\` and \`--host_cxxopt\`) so unrecognized warning flags are silently ignored instead of fatal, matching the escape hatch Valdi's own \`WARNING_FLAGS\` already relies on internally.

## Test plan
- [x] Reproduced locally on Apple Clang 17: \`bazel test //valdi_modules/widgets:test\` failed with \`error: unknown warning option '-Wno-nontrivial-memcall' ... [-Werror,-Wunknown-warning-option]\` before this change.
- [x] Same command builds and passes after this change.