### PR TITLE
Track Valdi main in CI: fix nightly (abseil + palette) and align PR gate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,6 @@ jobs:
             --override_module=skia_user_config=$VALDI/third-party/skia_user_config \
             --override_module=rules_hdrs=$VALDI/third-party/rules_hdrs \
             --override_module=valdi_toolchain=$VALDI/bin \
-            --override_module=resvg_libs=$VALDI/third-party/resvg/resvg_libs \
             //valdi_modules/widgets:test \
             //valdi_modules/navigation:test \
             //valdi_modules/valdi_standalone_ui:test \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: Snapchat/Valdi
-          ref: beta-0.1.0
+          # Track Valdi main so PRs are gated against the same bleeding-edge
+          # Valdi the nightly builds against. Widgets follows Valdi main; a
+          # pinned release tag drifts out of sync (protobuf/runtime API).
+          ref: main
           lfs: true
           path: .valdi
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -77,7 +77,11 @@ rules_ts_ext = use_extension("@aspect_rules_ts//ts:extensions.bzl", "ext")
 use_repo(rules_ts_ext, "npm_typescript")
 
 # Version pins (must match Valdi's MODULE.bazel).
-single_version_override(module_name = "protobuf", version = "27.0")
+single_version_override(module_name = "protobuf", version = "29.3")
+# protobuf 29.3 references @abseil-cpp//absl/utility:if_constexpr, a target that
+# abseil 20250814.x removed (folded into :utility). Pin abseil to the release
+# Valdi resolves so MVS doesn't drag it up to an incompatible version.
+single_version_override(module_name = "abseil-cpp", version = "20250127.0")
 single_version_override(module_name = "rules_apple", version = "4.0.0")
 single_version_override(module_name = "rules_pkg", version = "0.9.1")
 single_version_override(module_name = "zlib", version = "1.3.2")

--- a/valdi_modules/widgets/src/InitSemanticColors.ts
+++ b/valdi_modules/widgets/src/InitSemanticColors.ts
@@ -20,9 +20,18 @@ declare const global: {
   theme: string;
 };
 
+// Name of the single named palette widgets keeps active. The runtime's
+// setColorPalette(palette) was replaced by the named-palette API
+// (configureColorPalette + setActiveColorPalette); reconfiguring one name and
+// keeping it active reproduces the old "apply this palette now" behavior —
+// configureColorPalette refreshes listeners when the colors change, and
+// setActiveColorPalette activates it once.
+const ACTIVE_PALETTE_NAME = 'widgetsSemanticColors';
+
 function updateColorPalette(palette: ColorPalette): void {
   global.currentPalette = palette;
-  runtime.setColorPalette(palette);
+  runtime.configureColorPalette(ACTIVE_PALETTE_NAME, palette);
+  runtime.setActiveColorPalette(ACTIVE_PALETTE_NAME);
 }
 
 if (!global.currentPalette) {


### PR DESCRIPTION
Valdi_Widgets follows Valdi **main**, but its two CI workflows had drifted apart:

- `nightly.yml` builds against Valdi **main** — failing every run since ~Aug 31.
- `test.yml` (PR gate) built against Valdi **beta-0.1.0**, a release that has since diverged from main on protobuf version *and* the color-palette runtime API.

No single set of pins/source could satisfy both. This PR aligns everything on main.

## Changes

1. **`MODULE.bazel` — pin abseil-cpp to `20250127.0`, protobuf to `29.3`.**
   abseil `20250814.x` removed `absl/utility:if_constexpr` (folded into `:utility`), which protobuf references; once MVS selected it, nightly analysis aborted with `no such target ...:if_constexpr`. Pin abseil to the release Valdi resolves; align protobuf to main's `29.3`.

2. **`InitSemanticColors.ts` — migrate off removed `runtime.setColorPalette`.**
   Valdi main replaced it with `configureColorPalette(name, palette)` + `setActiveColorPalette(name)`. Keep one named palette active and reconfigure it per update — verified against the C++ (`ColorPalette.cpp`) that this reproduces the old single-palette refresh behavior.

3. **`test.yml` — build against Valdi `main`, not `beta-0.1.0`.**
   So the PR gate and the nightly test the same bleeding-edge Valdi. The pinned release drifted out of sync (protobuf 27.0, old palette API); main is 29.3 with the new API.

## Verification

Full nightly suite, against Valdi main, in a fresh Bazel output base with no remote cache (protos compiled cold in the exec config — the action that failed in CI):

```
//valdi_modules/navigation:test           PASSED
//valdi_modules/navigation_internal:test  PASSED
//valdi_modules/playground:test           PASSED
//valdi_modules/valdi_standalone_ui:test  PASSED
//valdi_modules/widgets:test              PASSED
Executed 5 out of 5 tests: 5 tests pass.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)